### PR TITLE
Fixing two errors in the module.

### DIFF
--- a/src/Api/RatingService.php
+++ b/src/Api/RatingService.php
@@ -22,6 +22,14 @@ class RatingService extends RequestServiceBase implements RatingServiceInterface
      * {@inheritdoc}
      */
     public function getRates(ShippingMethodInterface $shipping_method, ShipmentInterface $shipment, array $options) {
+        $countryCode = $shipment->getShippingProfile()
+            ->get('address')
+            ->first()
+            ->getCountryCode();
+        if ($countryCode !== 'CA') {
+          return [];
+        }
+
         $order = $shipment->getOrder();
         $store = $order->getStore();
 
@@ -41,10 +49,6 @@ class RatingService extends RequestServiceBase implements RatingServiceInterface
             ->get('address')
             ->first()
             ->getPostalCode();
-        $countryCode = $shipment->getShippingProfile()
-            ->get('address')
-            ->first()
-            ->getCountryCode();
         $weight = $shipment->getWeight()->convert('kg')->getNumber();
         $package = $shipment->getPackageType() ?: $shipping_method->getDefaultPackageType();
         $shipping_date = $this->getShippingDate();

--- a/src/UtilitiesService.php
+++ b/src/UtilitiesService.php
@@ -211,7 +211,7 @@ class UtilitiesService {
       $shipment_query->condition('order_id', $order_ids, 'IN');
     }
     // Fetch the results.
-    $shipment_ids = $shipment_query->execute();
+    $shipment_ids = $shipment_query->accessCheck()->execute();
 
     // Return the loaded shipment entities.
     return $this->entityTypeManager


### PR DESCRIPTION
The first one is:
> Drupal\Core\Entity\Query\QueryException: Entity queries must explicitly set whether the query should be access checked or not. See Drupal\Core\Entity\Query\QueryInterface::accessCheck(). in Drupal\Core\Entity\Query\Sql\Query->prepare()

That happens due to a missing accessCheck() in commerce_canadapost/src/UtilitiesService.php on line 214.

The second one is:
> An error has been returned by the Canada Post shipment method when fetching the shipping rates. The error was: "{"messages":{"message":[@"code":"9112","description":"The service DOM.EP is not available for the specified country or customer\/contract.",@"code":"9112","description":"The service DOM.XP is not available for the specified country or customer\/contract.",@"code":"9112","description":"The service INT.XP is not available for the specified country or customer\/contract.",@"code":"9112","description":"The service INT.SP.AIR is not available for the specified country or customer\/contract."]}}"

That happens due to not checking the country code before trying to get the Canada Post rates in src/Api/RatingService.php::getRates().
